### PR TITLE
修复Magnus的Service命名与之前版本不一致导致svc重新创建失败的问题

### DIFF
--- a/charts/jumpserver/templates/magnus/service-magnus.yaml
+++ b/charts/jumpserver/templates/magnus/service-magnus.yaml
@@ -11,7 +11,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $fullName }}-jm-magnus"
+  name: "{{ $fullName }}-jms-magnus"
   labels:
     {{- include "jumpserver.labels" $ | nindent 4 }}
     {{- toYaml .labels | nindent 4 }}


### PR DESCRIPTION
之前的版本命名为jms-k8s-jumpserver-jms-magnus
此版本命名为jms-k8s-jumpserver-jm-magnus
缺少一个s，导致svc需要重新创建，可能出现svc创建失败的问题